### PR TITLE
chore: add monthly Nix Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
       shuttle:
         patterns:
           - "*-eyre"
+  - package-ecosystem: nix
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Configure Dependabot to update Nix inputs monthly. This does not change any existing flake lockfile pins.