### PR TITLE
chore: align Dependabot update schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
   - package-ecosystem: cargo
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
     groups:
       shuttle:
         patterns:


### PR DESCRIPTION
Align Dependabot schedules with the repository baseline.

This changes only `.github/dependabot.yml`; it does not update Cargo.lock or Nix input hashes.
